### PR TITLE
Anonymize names sent to server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ HEADERS := $(wildcard *.h)
 BOWTIE_MM := 1
 BOWTIE_SHARED_MEM :=
 
-CXXFLAGS += -std=c++11 -Wall -Wno-unused-but-set-variable
+CXXFLAGS += -std=c++14 -Wall -Wno-unused-but-set-variable
 
 SRA_TOOLS_VER ?= 3.0.9
 VDB_VER ?= 3.0.9

--- a/aln_sink.cpp
+++ b/aln_sink.cpp
@@ -843,6 +843,13 @@ void AlnSinkWrap::finishRead(
 					met.nconcord_uni2++;
 				}
 			}
+			g_->appendReadComplete(
+				obuf_,
+				staln_,
+				threadid_,
+				rd1_,
+				rd2_,
+				rdid_);
 			init_ = false;
 			g_ = NULL;
 			return;
@@ -964,6 +971,13 @@ void AlnSinkWrap::finishRead(
 				false);
 			met.nconcord_0++;
 			met.ndiscord++;
+			g_->appendReadComplete(
+				obuf_,
+				staln_,
+				threadid_,
+				rd1_,
+				rd2_,
+				rdid_);
 			init_ = false;
 			g_ = NULL;
 			return;
@@ -1381,6 +1395,13 @@ void AlnSinkWrap::finishRead(
 				true);   // get lock?
 		}
 	} // if(suppress alignments)
+	g_->appendReadComplete(
+		obuf_,
+		staln_,
+		threadid_,
+		rd1_,
+		rd2_,
+		rdid_);
 	init_ = false;
 	g_ = NULL;
 	return;
@@ -2139,10 +2160,14 @@ void AlnSinkSam::appendReadComplete(
 		if (rd1!=NULL) {
 			o.append('\t');
 			samc_.printReadName(o, rd1->name, rd2!=NULL);
-		}
-		if (rd2!=NULL) {
+			// if (rd2!=NULL), the rd1->name==rd2->name, meaning unpaired
+		} else if (rd2!=NULL) {
 			o.append('\t');
 			samc_.printReadName(o, rd2->name, rd1!=NULL);
+		} else {
+			// should never get in here, but just in case
+			o.append("\t");
+			o.append("?");
 		}
 		o.append('\n');
 	}

--- a/aln_sink.cpp
+++ b/aln_sink.cpp
@@ -2126,6 +2126,29 @@ void AlnSinkSam::appendMate(
 
 }
 
+void AlnSinkSam::appendReadComplete(
+	BTString&             o,
+	StackedAln&           staln,
+	size_t                threadId,
+	const Read           *rd1,
+	const Read           *rd2,
+	const TReadId         rdid)
+{
+	if (sendReadComplete_) {
+		o.append("@CO END READ");
+		if (rd1!=NULL) {
+			o.append('\t');
+			samc_.printReadName(o, rd1->name, rd2!=NULL);
+		}
+		if (rd2!=NULL) {
+			o.append('\t');
+			samc_.printReadName(o, rd2->name, rd1!=NULL);
+		}
+		o.append('\n');
+	}
+	// nothing to do, else
+}
+
 #ifdef ALN_SINK_MAIN
 
 #include <iostream>

--- a/aln_sink.h
+++ b/aln_sink.h
@@ -746,7 +746,6 @@ public:
 				}
 			}
 		}
-		appendReadComplete(o, staln, threadId, rd1, rd2, rdid);
 	}
 
 	/**
@@ -773,7 +772,6 @@ public:
 	{
 		append(o, staln, threadId, rd1, rd2, rdid, NULL, NULL, summ,
 		       ssm1, ssm2, flags1, flags2, prm, mapq, sc, report2);
-		appendReadComplete(o, staln, threadId, rd1, rd2, rdid);
 	}
 
 	/**

--- a/bt2_search.cpp
+++ b/bt2_search.cpp
@@ -4562,7 +4562,7 @@ static void webLoadWorker(void *vp) {
 	try {
 		// we want it slightly larger the internal buffer, but more does not hurt
 		const int n_writecache = 2*PatternSourceWebClient::RE_PER_PACKET;
-		PatternSourceWebClient::Config config(multiseedIndexName.c_str());
+		PatternSourceWebClient::Config config(multiseedIndexName.c_str(), sam_print_xr);
 		PatternSourceWebClient cobj(multiseedServerHostname.c_str(), multiseedServerPort, *samOfb, config, n_writecache);
 		if (!cobj.goodState()) {
 			fprintf(stderr, "ERROR: Failed to connect to %s:%i!\n",multiseedServerHostname.c_str(),multiseedServerPort);

--- a/pat.cpp
+++ b/pat.cpp
@@ -2244,7 +2244,7 @@ void PatternSourceWebClient::ReadElement::append(const char chr) {
 	tab6_len++;
 }
 
-void PatternSourceWebClient::ReadElement::origbuf_alloc(uint32_t size) {
+void PatternSourceWebClient::OrigBuf::origbuf_alloc(uint32_t size) {
 	if  (readPairOrigBuf_capacity<size) {
 		if (readPairOrigBuf!=NULL) delete[] readPairOrigBuf;
 		readPairOrigBuf = new char[size];
@@ -2252,7 +2252,7 @@ void PatternSourceWebClient::ReadElement::origbuf_alloc(uint32_t size) {
 	} // else, reuse the same buffer
 }
 
-void PatternSourceWebClient::ReadElement::saveOrigBufs(const Read& read_a, const Read& read_b) {
+void PatternSourceWebClient::OrigBuf::saveOrigBufs(const Read& read_a, const Read& read_b) {
 	readaOrigBuf_len = read_a.readOrigBuf.length();
 	readbOrigBuf_len = read_b.empty() ? 0 : read_b.readOrigBuf.length();
 	readaNameBuf_len = read_a.name.length();
@@ -2307,7 +2307,7 @@ void PatternSourceWebClient::ReadElement::readPair2Tab6(const Read& read_a, cons
 		out.append(read_b.qual.toZBuf(),read_b.qual.length());
 	}
 	out.append('\0');
-	out.saveOrigBufs(read_a,read_b);
+	out.readPairOrigBuf.saveOrigBufs(read_a,read_b);
 }
 
 // read until \n\n detected

--- a/pat.cpp
+++ b/pat.cpp
@@ -2228,10 +2228,6 @@ void PatternSourceWebClient::ReadElement::tab6_alloc(uint32_t size) {
 void PatternSourceWebClient::ReadElement::clear_and_alloc(uint32_t size) {
 	tab6_alloc(size);
 	tab6_len = 0;
-	readaNameBuf_offs = 0;
-	readbNameBuf_offs = 0;
-	readaNameBuf_len = 0;
-	readbNameBuf_len = 0;
 }
 
 // assumes the buffer is already allocated and large enough
@@ -2259,9 +2255,31 @@ void PatternSourceWebClient::ReadElement::origbuf_alloc(uint32_t size) {
 void PatternSourceWebClient::ReadElement::saveOrigBufs(const Read& read_a, const Read& read_b) {
 	readaOrigBuf_len = read_a.readOrigBuf.length();
 	readbOrigBuf_len = read_b.empty() ? 0 : read_b.readOrigBuf.length();
-	origbuf_alloc(readaOrigBuf_len+readbOrigBuf_len);
-	if (readaOrigBuf_len>0) memcpy(readPairOrigBuf+0,               read_a.readOrigBuf.buf(),readaOrigBuf_len);
-	if (readbOrigBuf_len>0) memcpy(readPairOrigBuf+readaOrigBuf_len,read_b.readOrigBuf.buf(),readbOrigBuf_len);
+	readaNameBuf_len = read_a.name.length();
+	readbNameBuf_len = read_b.empty() ? 0 : read_b.name.length();
+
+	const uint32_t readbOrigBufPair_len = readOrigBuf_len();
+	assert(readbOrigBufPair_len == (readaOrigBuf_len+readbOrigBuf_len+readaNameBuf_len+readbNameBuf_len+4));
+	if (readbOrigBufPair_len>0) {
+		origbuf_alloc(readbOrigBufPair_len);
+		uint32_t off = 0;
+		if (readaOrigBuf_len>0) memcpy(readPairOrigBuf+off, read_a.readOrigBuf.buf(),readaOrigBuf_len);
+		off += readaOrigBuf_len;
+		readPairOrigBuf[off] = 0;
+		off++;
+		if (readbOrigBuf_len>0) memcpy(readPairOrigBuf+off, read_b.readOrigBuf.buf(),readaOrigBuf_len);
+		off += readbOrigBuf_len;
+		readPairOrigBuf[off] = 0;
+		off++;
+		if (readaNameBuf_len>0) memcpy(readPairOrigBuf+off, read_a.name.buf(),readaNameBuf_len);
+		off += readaNameBuf_len;
+		readPairOrigBuf[off] = 0;
+		off++;
+		if (readbNameBuf_len>0) memcpy(readPairOrigBuf+off, read_b.name.buf(),readbNameBuf_len);
+		off += readbNameBuf_len;
+		readPairOrigBuf[off] = 0;
+		off++;
+	}
 }
 
 // Returns a new string in tab6 format
@@ -2269,7 +2287,6 @@ void PatternSourceWebClient::ReadElement::saveOrigBufs(const Read& read_a, const
 // Note that the returned size does not include the terminating null character
 void PatternSourceWebClient::ReadElement::readPair2Tab6(const Read& read_a, const Read& read_b) {
 	uint32_t total_len = read_a.name.length()+1+read_a.patFw.length()+1+read_a.qual.length();
-	const uint32_t read_b_offs = total_len + 1; // only valid if !read_b.empty()
 	if (!read_b.empty()) {
 		// paired
 		total_len += 1+read_b.name.length()+1+read_b.patFw.length()+1+read_b.qual.length();
@@ -2290,11 +2307,6 @@ void PatternSourceWebClient::ReadElement::readPair2Tab6(const Read& read_a, cons
 		out.append(read_b.qual.toZBuf(),read_b.qual.length());
 	}
 	out.append('\0');
-	if (read_b.empty()) {
-		out.set_read_names(0,read_a.name.length(),0,0);
-	} else {
-		out.set_read_names(0,read_a.name.length(),read_b_offs,read_b.name.length());
-	}
 	out.saveOrigBufs(read_a,read_b);
 }
 

--- a/pat.cpp
+++ b/pat.cpp
@@ -2032,6 +2032,7 @@ bool PatternSourceServiceFactory::align(int fd, long int data_size) {
                 readsPerBatch,                   // size of output buffer of reads
                 0); // no reason to skip reads
 	AlnSinkSam msink(template_msink_, oq);
+	msink.sendReadComplete();
 
 	EList<PatternSource*>* comp_params  = new EList<PatternSource*>();
 	auto *ps = new TabbedSocketPatternSource(pp_, fd, data_size, &msink);

--- a/pat.h
+++ b/pat.h
@@ -2169,46 +2169,61 @@ private:
 public:
 	class ReadElement {
 	private:
+		// Buffer containing the tab6-formatted string
 		char    *tab6_str;
-		uint32_t capacity;
+		uint32_t tab6_capacity;
+		uint32_t tab6_len;
 	public:
-		ReadElement() : tab6_str(NULL), capacity(0), len(0) {}
+		ReadElement() : tab6_str(NULL), tab6_capacity(0), tab6_len(0) {}
 		~ReadElement() {
-			//if (tab6_str!=NULL) delete[] tab6_str;
+			reset();
 		}
 
-		ReadElement(const ReadElement& other) = default;
-		ReadElement& operator=(const ReadElement& other) = default;
+		ReadElement(const ReadElement& other) : tab6_str(NULL), tab6_capacity(0), tab6_len(other.tab6_len) {
+			clear_and_alloc(other.tab6_capacity);
+			if (tab6_len>0) {
+				memcpy(tab6_str, other.tab6_str,tab6_len);
+			}
+		}
 
-		ReadElement(ReadElement&& other) {
-			tab6_str = other.tab6_str;
+		ReadElement& operator=(const ReadElement& other) {
+			clear_and_alloc(other.tab6_capacity);
+			tab6_len = other.tab6_len;
+			if (tab6_len>0) {
+				memcpy(tab6_str, other.tab6_str,tab6_len);
+			}
+			return *this;
+		}
+
+		ReadElement(ReadElement&& other) : tab6_str(other.tab6_str), tab6_capacity(other.tab6_capacity), tab6_len(other.tab6_len){
 			other.tab6_str = NULL;
-			capacity = other.capacity;
-			other.capacity = 0;
-			len = other.len;
-			other.len = 0;
+			other.tab6_capacity = 0;
+			other.tab6_len = 0;
 		}
 
 		// fill this buffer with tab6 data from the two reads
 		void readPair2Tab6(const Read& read_a, const Read& read_b);
 
 		bool empty() { return tab6_str==NULL; }
+
 		char *buf() {return tab6_str;};
 		const char *buf() const {return tab6_str;};
+		uint32_t buf_len() const {return tab6_len;}
 
-		uint32_t len;
 
 		// =======================
 		// mostly for internal use
 
 		void clear_and_alloc(size_t size);
+		// assumes the buffer is already allocated and large enough
 		void append(const char *str, size_t str_len);
+		// assumes the buffer is already allocated and large enough
 		void append(const char chr);
 		void reset() {
 			if (tab6_str!=NULL) delete[] tab6_str;
 			tab6_str = NULL;
-			capacity=0;
-			len=0;
+			tab6_capacity=0;
+			tab6_len=0;
 		}
 	};
 

--- a/pat.h
+++ b/pat.h
@@ -2696,6 +2696,9 @@ private:
 	// returns true if it finds one
 	static bool find_request_terminator(const char str[]);
 
+	static bool process_read_buffer(OutFileBuf& obuf, char recv_str[], int& recv_filled);
+	static void process_read_line(OutFileBuf& obuf, char line_buf[], const int line_size);
+
 	static constexpr int MAX_HEADER_SIZE = 1023;
 
 	static void close_socket(int fd);


### PR DESCRIPTION
Send only anonymous names to the server, instead of the original names.
Also fix handling of paired reads.

Note: The results are not identical to original bowtie2 anymore, as the random seeds use the read name in the hash.